### PR TITLE
Use promise-based ConfirmChannel instead of amqplib's native one

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,5 @@
-import { Channel, ConfirmChannel, Connection } from 'amqplib-as-promised/lib';
+import { Channel, Connection } from 'amqplib-as-promised/lib';
+import { ConfirmChannel } from 'amqplib-as-promised/lib/confirm-channel';
 import { FastifyPluginAsync } from 'fastify';
 
 declare namespace fastifyAmqpAsync {

--- a/index.test-d.ts
+++ b/index.test-d.ts
@@ -1,4 +1,5 @@
-import { Channel, Connection, ConfirmChannel } from 'amqplib-as-promised/lib';
+import { Channel, Connection } from 'amqplib-as-promised/lib';
+import { ConfirmChannel } from 'amqplib-as-promised/lib/confirm-channel';
 import Fastify, { FastifyInstance } from 'fastify';
 import { expectAssignable, expectType } from 'tsd';
 import fastifyAmqpAsync from './index';


### PR DESCRIPTION
Resolves #3 this change may be reverted in the future if the underlying problem in amqplib-as-promised is resolved.